### PR TITLE
Fix returned value when image is already optimized

### DIFF
--- a/lib/paperclip-optimizer/processor.rb
+++ b/lib/paperclip-optimizer/processor.rb
@@ -31,7 +31,7 @@ module Paperclip
       if compressed_file_path && File.exist?(compressed_file_path)
         return File.open(compressed_file_path)
       else
-        return @file
+        return File.new(@file.path)
       end
     end
 


### PR DESCRIPTION
When the image does not need optimization, a new instance of File object should be returned instead of the original `@file` object, which is closed for further modification.

see http://stackoverflow.com/questions/25112289/paperclip-processor-to-return-the-file-untouched